### PR TITLE
Update dependencies to ensure Java7 compatibility.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.google.code.javaparser</groupId>
             <artifactId>javaparser</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.11</version>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/org/fourthline/lemma/pipeline/javadoc/XHTMLTemplateJavadocPipeline.java
+++ b/core/src/main/java/org/fourthline/lemma/pipeline/javadoc/XHTMLTemplateJavadocPipeline.java
@@ -194,11 +194,11 @@ public class XHTMLTemplateJavadocPipeline extends Pipeline<XHTML, XHTML> {
      */
     public static class SharedOptions {
 
-        @Option(required = true, name = "-d", metaVar = "<path>", multiValued = true,
+        @Option(required = true, name = "-d", metaVar = "<path>",
                 usage = "The base path(s) of all source and resource files.")
         public List<File> sourceDirectories = new ArrayList();
 
-        @Option(required = false, name = "-p", metaVar = "<package.name>", multiValued = true,
+        @Option(required = false, name = "-p", metaVar = "<package.name>",
                 usage = "Included package, repeat option for multiple packages.")
         public List<String> packageNames = new ArrayList();
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -43,14 +43,14 @@
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-impl</artifactId>
-            <version>2.0.5</version>
+            <version>2.3</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>2.0.5</version>
+            <version>3.0.21</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>5</maven.compiler.source>
-        <maven.compiler.target>5</maven.compiler.target>
+        <maven.compiler.source>6</maven.compiler.source>
+        <maven.compiler.target>6</maven.compiler.target>
 
-        <seamless.version>1.0.0</seamless.version>
-        <testng.version>6.2</testng.version>
-        <args4j.version>2.0.12</args4j.version>
+        <seamless.version>1.1.0</seamless.version>
+        <testng.version>6.8.21</testng.version>
+        <args4j.version>2.32</args4j.version>
 
     </properties>
 


### PR DESCRIPTION
Javaparser 1.0.11 improves handling of Java7 generics.